### PR TITLE
Fix last_response_id tracking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -157,7 +157,6 @@ async def message_handler(message: Message, bot: Bot) -> None:
 
             # 3) Асинхронный вызов OpenAI API
             response = client.responses.create(**kwargs)
-            user_states[chat_id]['last_response_id'] = response.id
 
             # Проверяем наличие вызова функции
             is_funny = False
@@ -191,6 +190,7 @@ async def message_handler(message: Message, bot: Bot) -> None:
             kwargs["input"] = input_data
             # Получаем финальный ответ
             response = client.responses.create(**kwargs)
+            user_states[chat_id]['last_response_id'] = response.id
 
             # 4) Извлекаем текст из ответа
             if response.output and len(response.output) > 0:


### PR DESCRIPTION
## Summary
- set `last_response_id` only after final API call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee5e830d48332b5b334007d3d42e8